### PR TITLE
perf: use decrement instead of splice/indexOf

### DIFF
--- a/lib/asyncgraph.js
+++ b/lib/asyncgraph.js
@@ -46,16 +46,15 @@ Graph.prototype.listEvents = function() {
 };
 
 Graph.prototype._onAll = function onAll(arr, func) {
-    var notRunYet = [].slice.call(arr);
-    var self = this;
-    arr.forEach(function(eventName){
-        self.on(eventName, function(){
-            notRunYet.splice(notRunYet.indexOf(eventName), 1);
-            if (!notRunYet.length) {
+    var notRunYet = arr.length, len = notRunYet, i, eventName;
+    for (i = 0; i < len; i++) {
+        eventName = arr[i];
+        this.on(eventName, function(){
+            if (! --notRunYet) {
                 func();
             }
         });
-    });
+    }
 };
 
 Graph.prototype._emitSuccess = function(obj) {


### PR DESCRIPTION
In `_onAll`, individual elements were being removed from an array to track
if they had been run. In reality, all that's needed is to know when
_all_ of them have been run. This can be acheived by simply getting
the original array length, and decrementing it upon completion of an
element, with a stop condition when the count is zero.

In a small benchmark, this **increased speeds for resolution of a graph by
roughly 4.5x**. This was clearly the lowest hanging fruit in terms of
performance of asyncgrpah.
